### PR TITLE
Fix for multiple bugs

### DIFF
--- a/src/DotNetCorePrerender/DotNetCoreOpen.PrerenderMiddleware/Constants.cs
+++ b/src/DotNetCorePrerender/DotNetCoreOpen.PrerenderMiddleware/Constants.cs
@@ -15,6 +15,7 @@ namespace DotNetCoreOpen.PrerenderMiddleware
         public const string EscapedFragment = "_escaped_fragment_";
         public const string HttpProtocol = "http://";
         public const string HttpsProtocol = "https://";
+        public const string Https = "https";
         public const string HttpHeader_XForwardedProto = "X-Forwarded-Proto";
         public const string HttpHeader_XPrerenderToken = "X-Prerender-Token";
         public const string HttpHeader_UserAgent = "User-Agent";

--- a/src/DotNetCorePrerender/DotNetCoreOpen.PrerenderMiddleware/PrerenderMiddleware.cs
+++ b/src/DotNetCorePrerender/DotNetCoreOpen.PrerenderMiddleware/PrerenderMiddleware.cs
@@ -21,7 +21,7 @@ namespace DotNetCoreOpen.PrerenderMiddleware
     public class PrerenderMiddleware
     {
         #region Static ReadOnly        
-        const string DefaultIgnoredExtensions = "\\.vxml|js|css|less|png|jpg|jpeg|gif|pdf|doc|txt|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent";
+        const string DefaultIgnoredExtensions = "\\.(vxml|js|css|less|png|jpg|jpeg|gif|pdf|doc|txt|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent)";
         static readonly Encoding DefaultEncoding = Encoding.UTF8;
         #endregion
 
@@ -64,7 +64,7 @@ namespace DotNetCoreOpen.PrerenderMiddleware
                 // generate URL
                 var requestUrl = request.GetDisplayUrl();
                 // if traffic is forwarded from https://, we convert http:// to https://.
-                if (string.Equals(request.Headers[Constants.HttpHeader_XForwardedProto], Constants.HttpsProtocol, StringComparison.OrdinalIgnoreCase)
+                if (string.Equals(request.Headers[Constants.HttpHeader_XForwardedProto], Constants.Https, StringComparison.OrdinalIgnoreCase)
                  && requestUrl.StartsWith(Constants.HttpProtocol, StringComparison.OrdinalIgnoreCase))
                 {
                     requestUrl = Constants.HttpsProtocol + requestUrl.Substring(Constants.HttpProtocol.Length);
@@ -134,9 +134,9 @@ namespace DotNetCoreOpen.PrerenderMiddleware
                 return false;
 
             // check if it's crawler user agent.
-            var crawlerUserAgentPattern = Configuration.CrawlerUserAgentPattern ?? Constants.CrawlerUserAgentPattern;
+            var crawlerUserAgentPattern = string.IsNullOrEmpty(Configuration.CrawlerUserAgentPattern) ? Constants.CrawlerUserAgentPattern : Configuration.CrawlerUserAgentPattern;
             if (string.IsNullOrEmpty(crawlerUserAgentPattern)
-             || !Regex.IsMatch(userAgent, crawlerUserAgentPattern, RegexOptions.IgnorePatternWhitespace))
+             || !Regex.IsMatch(userAgent, crawlerUserAgentPattern, RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnoreCase))
                 return false;
 
             // check if the extenion matchs default extension


### PR DESCRIPTION
Hi @dingyuliang 

First of all, thanks for porting the prerender middleware to .NET Core! This is really useful.
While using your package I've encountered some bugs which I try to fix in this pull request.
I'm actively testing the code changes in a live product of the company I work for.

**This pull request addresses the following bugs:**

The check for the `X-Forwarded-Proto`-Header uses the constant `HttpsProtocol` which is `"https://"`. The comparison cannot be true because the header only contains `"https"`, therefore I've added a new constant value to check against.

The default ignored extensions regex is not surrounded by parentheses, this leads to false positives e.g. if the URL contains `js` _anywhere_ the prerender service will not be used.
A safer approach would be to only check if the string ends with one of the extensions.

I've added Ignore Case options to the crawler user agent pattern check for more robustness (Facebook was not recognized before).
Furthermore, the short comparison `Configuration.CrawlerUserAgentPattern ??
 Constants.CrawlerUserAgentPattern` actually results in an empty string because it is a truthy value in C#. Added string.IsNullOrEmpty with a ternary expression to fix that.


Please let me know if I've missed anything and feel free to edit :)