### PR TITLE
Add googlebot and bingbot to list of crawler user agents

### DIFF
--- a/src/DotNetPrerender/DotNetOpen.PrerenderModule/Constants.cs
+++ b/src/DotNetPrerender/DotNetOpen.PrerenderModule/Constants.cs
@@ -11,7 +11,7 @@ namespace DotNetOpen.PrerenderModule
         #region Const
         public const string PrerenderIOServiceUrl = "http://service.prerender.io/";
         public const int DefaultPort = 80;
-        public const string CrawlerUserAgentPattern = "(google)|(bing)|(Slurp)|(DuckDuckBot)|(YandexBot)|(baiduspider)|(Sogou)|(Exabot)|(ia_archiver)|(facebot)|(facebook)|(twitterbot)|(rogerbot)|(linkedinbot)|(embedly)|(quora)|(pinterest)|(slackbot)|(redditbot)|(Applebot)|(WhatsApp)|(flipboard)|(tumblr)|(bitlybot)|(Discordbot)";
+        public const string CrawlerUserAgentPattern = "(bingbot)|(googlebot)|(google)|(bing)|(Slurp)|(DuckDuckBot)|(YandexBot)|(baiduspider)|(Sogou)|(Exabot)|(ia_archiver)|(facebot)|(facebook)|(twitterbot)|(rogerbot)|(linkedinbot)|(embedly)|(quora)|(pinterest)|(slackbot)|(redditbot)|(Applebot)|(WhatsApp)|(flipboard)|(tumblr)|(bitlybot)|(Discordbot)";
 
         public const string EscapedFragment = "_escaped_fragment_";
         public const string HttpProtocol = "http://";


### PR DESCRIPTION
Prerender.io docs recommend to upgrade these:
https://prerender.io/documentation/google-support

>Make sure to update your Prerender.io middleware or manually add googlebot and bingbot to the list of user agents being checked by your Prerender.io middleware. See the bottom of this page for examples on adding googlebot to your middleware.

> There have been some reported issues with Googlebot rendering JavaScript on the first request to a URL that still uses the ?_escaped_fragment_= protocol, so upgrading will prevent any issues by serving a prerendered page directly to Googlebot on the first request.